### PR TITLE
Add companion list modal and integration with guest list

### DIFF
--- a/src/components/UI/Modal/CompanionListModal.vue
+++ b/src/components/UI/Modal/CompanionListModal.vue
@@ -1,0 +1,51 @@
+<script setup>
+import CWMModal from '@/components/UI/Modal/CWMModal.vue'
+import { ref, watch } from 'vue'
+
+const emit = defineEmits(['closeModal'])
+const props = defineProps({
+  open: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const showModal = ref(props.open)
+
+const handleClose = () => {
+  emit('closeModal')
+}
+
+
+watch(() => props.open, (newValue) => {
+  showModal.value = newValue
+})
+</script>
+
+<template>
+  <CWMModal :show-modal="showModal" @close="handleClose">
+    <template #header> Companions List </template>
+
+    <template #body>
+      This is the companion list component.
+    </template>
+
+    <template #footer>
+      <div
+        class="flex justify-end"
+      >
+        <div class="action-container flex gap-x-2">
+          <button
+            type="button"
+            class="bg-gray-500 hover:bg-gray-600 text-white text-sm font-medium py-2 px-6 rounded-md"
+            @click="handleClose"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </template>
+  </CWMModal>
+</template>
+
+<style scoped></style>

--- a/src/components/authenticated/guests/EventGuestList.vue
+++ b/src/components/authenticated/guests/EventGuestList.vue
@@ -6,6 +6,7 @@ import { useEventsStore } from '@/stores/useEventsStore'
 import { useNotificationStore } from '@/stores/useNotificationStore'
 import { useGuestsStore } from '@/stores/useGuestStore'
 import CWMAlert from '@/components/UI/alerts/CWMAlert.vue'
+import CompanionListModal from '@/components/UI/Modal/CompanionListModal.vue'
 
 const emit = defineEmits(['showAddGuest'])
 
@@ -17,6 +18,9 @@ const totalItems = ref(0)
 const eventStore = useEventsStore()
 const notificationStore = useNotificationStore()
 const guestStore = useGuestsStore()
+const companionsModal = ref(false)
+const selectedGuest = ref(null)
+
 
 onMounted(() => {
   loadEventGuests()
@@ -63,6 +67,11 @@ const handleUpdatePerPage = (value) => {
 
 const showAddGuestView = () => {
   emit('showAddGuest')
+}
+
+const showCompanionsList = (guest) => {
+  selectedGuest.value = guest
+  companionsModal.value = true
 }
 
 watch(pageSelected, () => {
@@ -156,8 +165,11 @@ watch(perPage, () => {
               </span>
             </span>
             <span v-else>
-              <span class="bg-yellow-300 text-white text-xs font-medium me-2 px-2.5 py-0.5
-                          rounded-full dark:bg-yellow-600 dark:text-white">
+              <span
+                class="bg-yellow-300 text-white text-xs font-medium me-2 px-2.5 py-0.5
+                          rounded-full dark:bg-yellow-600 dark:text-white cursor-pointer"
+                @click="showCompanionsList(guest)"
+              >
                 {{ guest.companionQty }}
               </span>
             </span>
@@ -171,7 +183,10 @@ watch(perPage, () => {
         </tbody>
       </table>
     </div>
-
+    <CompanionListModal
+      :open="companionsModal"
+      @close-modal="companionsModal = false"
+    ></CompanionListModal>
   </div>
   <CWMPagination
     v-if="eventGuests.length"


### PR DESCRIPTION
Introduced `CompanionListModal` component and connected it to the EventGuestList. Guests with companions can now view companion details via a clickable badge. This enhances the user experience by providing a dedicated modal for companion information.