### PR TITLE
Handle errors in addComment method with detailed logging

### DIFF
--- a/src/services/EventCommentsService.js
+++ b/src/services/EventCommentsService.js
@@ -50,15 +50,25 @@ class EventCommentsService {
   }
 
   async addComment({ eventId, userId, origin, comment }) {
-    return CWM_API.get('sanctum/csrf-cookie', {
-      baseURL: import.meta.env.VITE_API_URL,
-    }).then(async () => {
-      return await CWM_API.post(`event/${eventId}/comments`, {
-        userId,
-        origin,
-        comment
+    try {
+      return CWM_API.get('sanctum/csrf-cookie', {
+        baseURL: import.meta.env.VITE_API_URL,
+      }).then(async () => {
+        return await CWM_API.post(`event/${eventId}/comments`, {
+          userId,
+          origin,
+          comment
+        })
       })
-    })
+    } catch (error) {
+      console.error('Error details:', {
+        message: error.message,
+        response: error.response?.data,
+        status: error.response?.status
+      });
+      throw error;
+
+    }
   }
 
   async loadComments(eventId) {


### PR DESCRIPTION
Added a try-catch block to the addComment method in EventCommentsService.js to handle errors. Logged error details, including message, response data, and status, for better debugging and issue resolution.