### PR TITLE
Update mode logic and fix image upload behavior

### DIFF
--- a/src/components/authenticated/sweet-memories/CWMSweetMemories.vue
+++ b/src/components/authenticated/sweet-memories/CWMSweetMemories.vue
@@ -4,7 +4,6 @@ import { ref } from 'vue'
 import CreateUpdateSweetMemoriesConfig
   from '@/components/authenticated/sweet-memories/CreateUpdateSweetMemoriesConfig.vue'
 import ShowSweetMemories from '@/components/authenticated/sweet-memories/ShowSweetMemories.vue'
-
 const loading = ref(false)
 </script>
 

--- a/src/components/authenticated/sweet-memories/ImageUpload.vue
+++ b/src/components/authenticated/sweet-memories/ImageUpload.vue
@@ -129,7 +129,7 @@ const showUploadButton = computed(() => {
 
 const updatedNeeded = computed(() => {
   if (props.mode === 'create') {
-    return false
+    return true
   }
 
   return previews.value.some((image) => !image.isExisting)

--- a/src/stores/useSweetMemoriesStore.js
+++ b/src/stores/useSweetMemoriesStore.js
@@ -66,7 +66,7 @@ export const useSweetMemoriesStore = defineStore('sweetMemories', {
 
           }))
 
-          this.mode = 'update'
+          this.mode = (this.memoriesImages.length > 0) ? 'update' : 'create'
           return { success: true, images: this.memoriesImages }
         } else {
           this.mode = 'create'


### PR DESCRIPTION
Refine the determination of 'mode' based on memoriesImages length to ensure consistency between 'update' and 'create' states. Adjust ImageUpload logic to correctly flag updates needed in 'create' mode. Minor cleanup in CWMSweetMemories.vue by removing an unused line.