### PR TITLE
Add download component and toggle functionality for RSVP totals

### DIFF
--- a/src/views/internal/rsvp/RsvpView.vue
+++ b/src/views/internal/rsvp/RsvpView.vue
@@ -24,9 +24,23 @@
           />
         </div>
 
-        <CButton variant="primary" @click="sendInvitations" :disabled="!selectedGuests.length">
-          Send Invitation to Selected
-        </CButton>
+        <div
+          class="flex items-center gap-4"
+        >
+          <RsvpDownload
+            :current-page="currentPage"
+            :per-page="perPage"
+            :rsvp-status="rsvpStatus"
+            :search-value="searchValue"
+            :event-id="userStore.activeEvent"
+            class="ml-4"
+          />
+          <CButton variant="primary" @click="sendInvitations" :disabled="!selectedGuests.length">
+            Send Invitation to Selected
+          </CButton>
+        </div>
+
+
       </div>
 
       <div class="overflow-x-auto">
@@ -72,12 +86,7 @@
         </div>
       </div>
 
-      <div class="flex items-center gap-4 justify-start mt-6">
-        <RsvpTotals />
-
-        <RsvpDownload />
-      </div>
-
+      <RsvpTotals />
     </div>
   </div>
   <CRsvpDetailsModal

--- a/src/views/internal/rsvp/components/RsvpTotals.vue
+++ b/src/views/internal/rsvp/components/RsvpTotals.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
-    <CButton variant="outline" @click="loadTotals" :disabled="loading">
+    <CButton variant="outline" @click="toggleShowTotals" :disabled="loading">
       <LucideBarChart2 class="w-4 h-4 mr-2" /> Show Totals
     </CButton>
 
-    <div v-if="totals" class="mt-4 bg-white dark:bg-gray-900 shadow-card rounded-2xl p-6">
+    <div v-if="showTotals" class="mt-4 bg-white dark:bg-gray-900 shadow-card rounded-2xl p-6">
       <h3 class="text-lg font-semibold text-gray-800 dark:text-white mb-4">RSVP Summary</h3>
       <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
         <div v-for="(value, label) in formattedTotals" :key="label" class="text-center">
@@ -30,6 +30,15 @@ const notifications = useNotificationStore()
 
 const totals = ref(null)
 const loading = ref(false)
+const showTotals = ref(false)
+
+const toggleShowTotals = async () => {
+  showTotals.value = !showTotals.value
+  if (!totals.value) {
+    await loadTotals()
+  }
+
+}
 
 const loadTotals = async () => {
   try {


### PR DESCRIPTION
Introduced an `RsvpDownload` component alongside the invitation button and improved the `RsvpTotals` toggle functionality with a `showTotals` state. This refactor enhances usability and ensures totals are only loaded when required.