### PR TITLE
Add functionality to revert RSVP confirmation

### DIFF
--- a/src/services/RsvpService.js
+++ b/src/services/RsvpService.js
@@ -60,6 +60,10 @@ class RsvpService {
       responseType: 'blob'
     })
   }
+
+  async revertConfirmation({ guestId, eventId }) {
+    return CWM_API.post(`event/${eventId}/rsvp/guests/${guestId}/revert-confirmation`)
+  }
 }
 
 export default new RsvpService()

--- a/src/stores/useRsvpStore.js
+++ b/src/stores/useRsvpStore.js
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import RsvpService from '../services/RsvpService'
+import { useUserStore } from '@/stores/useUserStore'
 
 export const useRsvpStore = defineStore('rsvpStore', {
   state: () => ({
@@ -40,6 +41,13 @@ export const useRsvpStore = defineStore('rsvpStore', {
         exportType,
         perPage,
         currentPage
+      })
+    },
+    revertConfirmation({ guestId }) {
+      const userStore = useUserStore()
+      return RsvpService.revertConfirmation({
+        guestId,
+        eventId: userStore.activeEvent
       })
     }
 

--- a/src/views/internal/rsvp/RsvpView.vue
+++ b/src/views/internal/rsvp/RsvpView.vue
@@ -93,6 +93,7 @@
     v-model="showDetailsModal"
     :guest="selectedGuest"
     @close="showDetailsModal = false"
+    @confirmation-reverted="handleConfirmationReverted"
   />
 </template>
 
@@ -111,7 +112,6 @@ import CPagination from '@/components/UI/pagination/CPagination.vue'
 import CInput from '@/components/UI/form2/CInput.vue'
 import RsvpTotals from '@/views/internal/rsvp/components/RsvpTotals.vue'
 import RsvpGuestTr from '@/views/internal/rsvp/components/RsvpGuestTr.vue'
-import { LucideDownload } from 'lucide-vue-next'
 import RsvpDownload from '@/views/internal/rsvp/components/RsvpDownload.vue'
 
 const perPageOptions = [
@@ -170,7 +170,6 @@ const loadGuests = async () => {
 }
 
 const viewGuest = (guest) => {
-  console.log('checking emit', guest)
   selectedGuest.value = guest
   showDetailsModal.value = true
 }
@@ -182,6 +181,11 @@ const sendInvitations = () => {
 const reloadGuests = () => {
   loadGuests()
   window.scrollTo({ top: 0, behavior: 'smooth' })
+}
+
+const handleConfirmationReverted = async () => {
+  await loadGuests()
+  showDetailsModal.value = false
 }
 
 onMounted(loadGuests)


### PR DESCRIPTION
Added a "Revert Confirmation" button with loading state and connected it to a new API endpoint. Updated relevant store, service logic, and modal behavior to handle reverting of RSVP confirmation seamlessly.