### PR TITLE
Add scroll-based visibility for SwipeLeft icon

### DIFF
--- a/src/views/non-authenticated/templates/butterfly-vision/SwipeLeftIcon/SwipeLeftIcon.vue
+++ b/src/views/non-authenticated/templates/butterfly-vision/SwipeLeftIcon/SwipeLeftIcon.vue
@@ -1,12 +1,39 @@
 <script setup>
 import SwipeLeft from '@/assets/images/Swipe/swipe-left.gif'
+import { onMounted, onUnmounted, ref } from 'vue'
 
+const showSwipe = ref(true)
+let scrollContainer = null
+
+const handleScroll = () => {
+  const scrollY = scrollContainer?.scrollTop ?? 0
+  showSwipe.value = scrollY <= 200
+}
+
+onMounted(() => {
+  scrollContainer = document.querySelector('main')
+  if (scrollContainer) {
+    scrollContainer.addEventListener('scroll', handleScroll)
+    handleScroll()
+  }
+})
+
+onUnmounted(() => {
+  if (scrollContainer) {
+    scrollContainer.removeEventListener('scroll', handleScroll)
+  }
+})
 </script>
 
 <template>
-  <div class="swipe-left fixed w-36 h-36 left-5">
-    <img :src="SwipeLeft" alt="Swipe Left" class="w-1/2 h-auto rounded-lg" />
-  </div>
+  <transition name="fade">
+    <div
+      v-if="showSwipe"
+      class="swipe-left fixed w-36 h-36 left-5 z-50"
+    >
+      <img :src="SwipeLeft" alt="Swipe Left" class="w-1/2 h-auto rounded-lg" />
+    </div>
+  </transition>
 </template>
 
 <style scoped>
@@ -17,5 +44,15 @@ import SwipeLeft from '@/assets/images/Swipe/swipe-left.gif'
 
 .swipe-left img {
   transform: rotate(90deg);
+}
+
+/* Fade transition */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.5s;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
 }
 </style>


### PR DESCRIPTION
Introduced a scroll listener to toggle the visibility of the SwipeLeft icon based on the scroll position. Added a smooth fade transition for better user experience when the icon appears or disappears.