### PR TITLE
Update event type validation and fix template syntax

### DIFF
--- a/src/components/UI/form2/CSelect.vue
+++ b/src/components/UI/form2/CSelect.vue
@@ -1,4 +1,4 @@
-<template>
+""<template>
   <div class="w-full">
     <label
       v-if="label"
@@ -103,3 +103,4 @@ select option {
   color: white !important;
 }
 </style>
+""

--- a/src/components/UI/form2/CSelect.vue
+++ b/src/components/UI/form2/CSelect.vue
@@ -103,4 +103,3 @@ select option {
   color: white !important;
 }
 </style>
-""

--- a/src/components/UI/form2/CSelect.vue
+++ b/src/components/UI/form2/CSelect.vue
@@ -1,4 +1,4 @@
-""<template>
+<template>
   <div class="w-full">
     <label
       v-if="label"

--- a/src/views/internal/events/CreateEventsView.vue
+++ b/src/views/internal/events/CreateEventsView.vue
@@ -231,7 +231,10 @@ const eventValidationSchema = computed(() => {
   return toTypedSchema(
     zod.object({
       eventName: zod.string().min(1, 'Event name is required.'),
-      eventType: zod.string().min(1, 'Event type is required.'),
+      eventType: zod.number({
+        required_error: 'Event type is required.',
+        invalid_type_error: 'Invalid event type.'
+      }),
       startDate: zod.string().min(1, 'Start date is required.'),
       endDate: zod.string().min(1, 'End date is required.'),
       status: zod.string().min(1, { message: 'Status is required' }),
@@ -265,6 +268,7 @@ onMounted(async () => {
     } else {
       const current = eventStore.activeEvent
       let features = {}
+
       eventStore.activeEvent.eventFeatures.forEach((feature) => {
         features[feature.name] = feature.isActive
       })


### PR DESCRIPTION
Changed eventType validation in CreateEventsView.vue to use a numeric schema with specific error messages. Also corrected unnecessary quotes in the template syntax of CSelect.vue.