### PR TITLE
Set the current menu after loading menus upon item removal

### DIFF
--- a/src/views/internal/menus/MenuItem.vue
+++ b/src/views/internal/menus/MenuItem.vue
@@ -26,6 +26,7 @@ const confirmRemoveItem = async () => {
 
     if (response.status === 200) {
       await menuStore.loadMenus()
+      await menuStore.setCurrentMenu(menuStore.currentMenu.id)
       notifications.addNotification({
         type: 'success',
         message: 'Menu item removed successfully.',


### PR DESCRIPTION
After removing a menu item, ensure the current menu is set explicitly to prevent state inconsistencies. This addition aligns with the menu store's update logic and improves overall stability.