### PR TITLE
Add 403 error handling and `C403.vue` error page

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -27,6 +27,14 @@ const router = createRouter({
       ]
     },
     {
+      path: '/403',
+      name: 'not-authorized',
+      component: () => import('@/views/internal/errors/C403.vue'),
+      meta: {
+        title: 'Not Authorized'
+      }
+    },
+    {
       path: '',
       name: 'Authenticated',
       component: InternalLayout,

--- a/src/services/axios.js
+++ b/src/services/axios.js
@@ -54,6 +54,7 @@ const onError = async (error) => {
         await handleUnauthorized()
         break;
       case 403:
+        await router.push('/403');
         console.log('Forbidden:', error.message);
         break;
       case 404:
@@ -70,7 +71,6 @@ const onError = async (error) => {
 const handleUnauthorized = async () => {
   const userStore = useUserStore()
   const notificationStore = useNotificationStore()
-  console.log('here qwe 123')
 
   await userStore.logOut()
 

--- a/src/views/internal/errors/C403.vue
+++ b/src/views/internal/errors/C403.vue
@@ -1,0 +1,19 @@
+<script setup>
+import { ShieldOff } from 'lucide-vue-next'
+</script>
+
+<template>
+  <div class="flex flex-col items-center justify-center h-full text-center py-16">
+    <ShieldOff class="w-16 h-16 text-red-500 mb-4" />
+    <h1 class="text-3xl font-bold text-red-600">Access Denied</h1>
+    <p class="text-gray-600 text-lg mt-2">
+      You do not have permission to access this resource.
+    </p>
+    <RouterLink
+      to="/dashboard"
+      class="mt-6 text-sm font-medium text-blue-500 hover:underline"
+    >
+      ← Back to Dashboard
+    </RouterLink>
+  </div>
+</template>


### PR DESCRIPTION
Introduce a new `C403.vue` component to display an "Access Denied" error page. Update Axios to redirect to `/403` on 403 errors and configure the router with a route for the error page. Clean up unused debug code in `axios.js`.