### PR TITLE
Update permission keys and add event permissions initialization

### DIFF
--- a/src/router/authRoutes.js
+++ b/src/router/authRoutes.js
@@ -28,7 +28,7 @@ const authRoutes = [
     meta: {
       title: 'Dashboard',
       requiresAuth: true,
-      requiredPermission: ['view_dashboard'],
+      // requiredPermission: ['view_dashboard'],
     }
   },
   {
@@ -48,7 +48,7 @@ const authRoutes = [
     meta: {
       title: 'Create Event',
       requiresAuth: true,
-      requiredPermission: ['create_events'],
+      requiredPermission: ['create_event'],
     }
   },
   {
@@ -58,7 +58,7 @@ const authRoutes = [
     meta: {
       title: 'Edit Event',
       requiresAuth: true,
-      requiredPermission: ['edit_events'],
+      requiredPermission: ['edit_event'],
     }
   },
   {
@@ -124,7 +124,7 @@ const authRoutes = [
     meta: {
       title: 'Create Guest',
       requiresAuth: true,
-      requiredPermission: ['create_guests'],
+      requiredPermission: ['create_guest'],
     }
   },
   {
@@ -154,7 +154,7 @@ const authRoutes = [
     meta: {
       title: 'Menus',
       requiresAuth: true,
-      requiredPermission: ['create_menus'],
+      requiredPermission: ['create_menu'],
     }
   },
   {
@@ -164,7 +164,7 @@ const authRoutes = [
     meta: {
       title: 'Show Menus',
       requiresAuth: true,
-      requiredPermission: ['view_menus'],
+      requiredPermission: ['view_menu'],
     }
   },
   {
@@ -174,7 +174,7 @@ const authRoutes = [
     meta: {
       title: 'Edit Menus',
       requiresAuth: true,
-      requiredPermission: ['edit_menus'],
+      requiredPermission: ['edit_menu'],
     }
   },
   {

--- a/src/stores/useEventsStore.js
+++ b/src/stores/useEventsStore.js
@@ -63,6 +63,10 @@ export const useEventsStore = defineStore('eventsStore', {
       this.activeEvent = event
     },
 
+    initEventPermissions(permissions) {
+      this.eventPermissions = permissions
+    },
+
     selectEvent(eventId) {
       const userStore = useUserStore()
       this.activeEvent = this.events.find((event) => event.id === eventId)

--- a/src/stores/useHydrationStore.js
+++ b/src/stores/useHydrationStore.js
@@ -25,6 +25,7 @@ export const useHydrationStore = defineStore('hydration', () => {
 
         useEventsStore().setEvents(data.events)
         useEventsStore().initActiveEvent(data.activeEvent)
+        useEventsStore().initEventPermissions(data.userPermissions)
         useMenusStore().setMenus(data.menus)
         useMenusStore().setMenuGuests(data.menuGuests)
         useGuestsStore().setGuests(data.guests)


### PR DESCRIPTION
Commented out an unused permission key and standardized permission keys to use singular forms for consistency. Added support for initializing event-specific permissions in the `useEventsStore` and linked it through the hydration process.