### PR TITLE
Update Save-the-Date subtitle naming

### DIFF
--- a/src/services/STDService.js
+++ b/src/services/STDService.js
@@ -7,7 +7,7 @@ class STDService {
    */
   prepareSTDFormData({
                        stdTitle = '',
-                       stdSubTitle = '',
+                       stdSubtitle = '',
                        backgroundColor = '',
                        image,
                        useCountdown = '',
@@ -16,7 +16,7 @@ class STDService {
                      }) {
     const formData = new FormData();
     formData.append('stdTitle', stdTitle);
-    formData.append('stdSubtitle', stdSubTitle);
+    formData.append('stdSubtitle', stdSubtitle);
     formData.append('backgroundColor', backgroundColor);
     formData.append('useCountdown', useCountdown);
     formData.append('useAddToCalendar', useAddToCalendar);

--- a/src/stores/useSaveTheDateStore.js
+++ b/src/stores/useSaveTheDateStore.js
@@ -61,7 +61,7 @@ export const useSaveTheDateStore = defineStore('stdStore', {
         this.id = legacyStd.id
         this.hasPreviousStd = true
         this.stdTitle = legacyStd.stdTitle || ''
-        this.stdSubTitle = legacyStd.stdSubTitle || ''
+        this.stdSubtitle = legacyStd.stdSubtitle || ''
         this.backgroundColor = legacyStd.backgroundColor || ''
         this.image = legacyStd.imageUrl || null
         this.useCountdown = !!legacyStd.useCountdown
@@ -74,7 +74,7 @@ export const useSaveTheDateStore = defineStore('stdStore', {
         this.id = null
         this.hasPreviousStd = false
         this.stdTitle = ''
-        this.stdSubTitle = ''
+        this.stdSubtitle = ''
         this.backgroundColor = ''
         this.image = null
         this.useCountdown = false
@@ -83,13 +83,13 @@ export const useSaveTheDateStore = defineStore('stdStore', {
     },
 
 
-    async createSTD({ stdTitle, stdSubTitle, backgroundColor, image, useCountdown, useAddToCalendar, isEnabled }) {
+    async createSTD({ stdTitle, stdSubtitle, backgroundColor, image, useCountdown, useAddToCalendar, isEnabled }) {
       const eventsStore = useEventsStore()
 
       return await STDService.createSTD({
         eventId: eventsStore?.currentEvent?.id,
         stdTitle,
-        stdSubTitle,
+        stdSubtitle,
         backgroundColor,
         image,
         useCountdown,
@@ -98,11 +98,11 @@ export const useSaveTheDateStore = defineStore('stdStore', {
       })
     },
 
-    async updateSTD({ stdTitle, stdSubTitle, backgroundColor, image, useCountdown, useAddToCalendar, isEnabled }) {
+    async updateSTD({ stdTitle, stdSubtitle, backgroundColor, image, useCountdown, useAddToCalendar, isEnabled }) {
       return await STDService.updateSTD({
         stdId: this.id,
         stdTitle,
-        stdSubTitle,
+        stdSubtitle,
         backgroundColor,
         image,
         useCountdown,

--- a/src/views/non-authenticated/templates/butterfly-vision/SaveTheDate/SaveTheDate.vue
+++ b/src/views/non-authenticated/templates/butterfly-vision/SaveTheDate/SaveTheDate.vue
@@ -63,7 +63,7 @@ onUnmounted(() => {
         v-if="true"
         class="text-2xl font-normal text-dark-blue z-10 text-center"
       >
-        <!--{{ saveTheDate.stdSubTitle }}-->
+        <!--{{ saveTheDate.stdSubtitle }}-->
         Este es un dia especial para nosotros, y queremos compartirlo contigo.
       </h3>
 


### PR DESCRIPTION
## Summary
- fix parameter naming in STDService
- align `useSaveTheDateStore` to use `stdSubtitle`
- update comment reference in Butterfly Vision SaveTheDate template

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f48fdd2c083309d7e7f9110c0c16b