### PR TITLE
Load Sweet Memories from API and bind data to Vue store

### DIFF
--- a/src/services/SweetMemoriesService.js
+++ b/src/services/SweetMemoriesService.js
@@ -112,6 +112,10 @@ class SweetMemoriesService {
       }
     })
   }
+
+  async loadSweetMemoriesV2({ eventId }) {
+    return await CWM_API.get(`event/${eventId}/sweet-memories-v2`)
+  }
 }
 
 export default new SweetMemoriesService()

--- a/src/stores/useSweetMemoriesStore.js
+++ b/src/stores/useSweetMemoriesStore.js
@@ -17,7 +17,8 @@ export const useSweetMemoriesStore = defineStore('sweetMemories', {
       picture: null,
       thumbnail: null
     },
-    mode: 'create'
+    mode: 'create',
+    memories: []
   }),
   actions: {
     async createSweetMemoriesConfig(eventId) {
@@ -92,11 +93,24 @@ export const useSweetMemoriesStore = defineStore('sweetMemories', {
 
     async createSweetMemory(memory) {
       const userStore = useUserStore()
-      console.log('checking memory in store', memory)
       return await SweetMemoriesService.createSweetMemory({
         eventId: userStore.activeEvent,
         ...memory
       })
+    },
+
+    async loadMemories() {
+      const userStore = useUserStore()
+      const response = await SweetMemoriesService.loadSweetMemoriesV2({
+        eventId: userStore.activeEvent
+      })
+
+      if (response.status === 200) {
+        this.memories = response.data.data || []
+        return { success: true, memories: this.memories }
+      } else {
+        return { success: false, error: response }
+      }
     }
   },
   getters: {}

--- a/src/views/internal/sweet-memories/CSweetMemories.vue
+++ b/src/views/internal/sweet-memories/CSweetMemories.vue
@@ -24,7 +24,6 @@
     <!-- Show list when not in edit mode -->
     <CSweetMemoriesList
       v-else
-      :memories="memories"
       @add="addNewMemory"
       @edit="editMemory"
       @delete="deleteMemory"
@@ -34,12 +33,14 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { onMounted, ref } from 'vue'
 import { Camera } from 'lucide-vue-next'
 
 import CSweetMemoriesForm from '@/views/internal/sweet-memories/CSweetMemoriesForm.vue'
 import CSweetMemoriesList from '@/views/internal/sweet-memories/CSweetMemoriesList.vue'
+import { useSweetMemoriesStore } from '@/stores/useSweetMemoriesStore'
 
+const sweetMemoriesStorage = useSweetMemoriesStore()
 const memories = ref([])
 const showForm = ref(false)
 const isEditing = ref(false)
@@ -99,5 +100,11 @@ const cancelEdit = () => {
 
 const handleOrderChange = newOrder => {
   memories.value = [...newOrder]
+
+  console.log(newOrder)
 }
+
+onMounted(async () => {
+  await sweetMemoriesStorage.loadMemories()
+})
 </script>

--- a/src/views/internal/sweet-memories/CSweetMemoriesList.vue
+++ b/src/views/internal/sweet-memories/CSweetMemoriesList.vue
@@ -8,11 +8,11 @@
       </CButton>
     </div>
 
-    <NoSweetMemories v-if="memories.length === 0" @add-first-memory="addMemory" />
+    <NoSweetMemories v-if="memories?.length === 0" @add-first-memory="addMemory" />
 
     <!-- Draggable Memories -->
     <draggable
-      v-if="memories.length > 0"
+      v-if="memories?.length > 0"
       class="space-y-6"
       :list="memories"
       item-key="id"
@@ -24,14 +24,12 @@
       <div v-for="memory in memories" :key="memory.id">
         <CCard class="relative">
           <div class="p-6">
-            <!-- Drag Handle -->
             <div class="absolute top-4 left-4 cursor-move drag-handle">
               <GripVertical class="w-6 h-6 text-gray-400" />
             </div>
 
             <div class="ml-8">
               <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <!-- Memory Image -->
                 <div>
                   <img
                     v-if="memory.imageUrl"
@@ -102,15 +100,16 @@ import { Plus, Trash2, GripVertical, Edit, Image as ImageIcon } from 'lucide-vue
 import CCard from '@/components/UI/cards/CCard.vue'
 import CButton from '@/components/UI/buttons/CButton.vue'
 import NoSweetMemories from '@/views/internal/sweet-memories/NoSweetMemories.vue'
-
-defineProps({
-  memories: {
-    type: Array,
-    required: true
-  }
-})
+import { useSweetMemoriesStore } from '@/stores/useSweetMemoriesStore'
+import { computed } from 'vue'
 
 const emit = defineEmits(['add', 'edit', 'delete', 'order-changed'])
+
+const sweetMemoriesStorage = useSweetMemoriesStore()
+
+const memories = computed(() => {
+  return sweetMemoriesStorage.memories || []
+})
 
 const addMemory = () => {
   emit('add')


### PR DESCRIPTION
Integrated `loadSweetMemoriesV2` API method for fetching memories and updated Vue store to manage the data. Refactored `CSweetMemories` and `CSweetMemoriesList` to dynamically display stored memories, ensuring a more reactive and maintainable component structure. Simplified memory prop usage and improved code clarity.